### PR TITLE
Make use of the dateform parameter

### DIFF
--- a/layouts/timeline/list.html
+++ b/layouts/timeline/list.html
@@ -11,14 +11,14 @@
 
     <section class="timeline">
       <div class="container" style="text-align: left!important">
-        {{ range .Pages.ByDate.Reverse  }} 
+        {{ range .Pages.ByDate.Reverse }} 
 
         <div class="timeline-item">
             <div class="timeline-img"></div>
 
             <div class="timeline-content js--fadeInLeft">
                 <h2><a href="{{.Permalink}}"><span class="post-title">{{.Title}}</span></a></h2>
-                <div class="date">{{ .Date.Format "Jan 2, 2006"}}</div>
+                <div class="date">{{ .Date.Format .Site.Params.dateform }}</div>
                 <p>
                     {{.Params.Eventname}}<br>
                     {{.Params.Eventlocation}}


### PR DESCRIPTION
I'm not sure if you're open to pull request. If you're not, you can ignore this one.

### User story

**I as** a developer **want to** change the date format displayed inside the _cards_ on my timeline by altering the ```config.toml``` file **so that** I can create a timeline which displays a period of time most convenient for my readers; for instance, if I create a week long schedule, only the days are important.

![image](https://user-images.githubusercontent.com/5946359/103178060-f72e8680-487f-11eb-9e09-064e8302cf6d.png)

### Elaboration

At the moment the date format of each _card_ on the timeline is fixed to  _Jan 2, 2006_. However, as date formats are described inside the ```config.toml```, why not make us of it. As _Jan 2, 2006_ matches the configured ```dateform``` inside the example site, I assume it is pervert to make use of ```.Site.Params.dateform``` for this case.

